### PR TITLE
[feat]: vcpkg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ bin/*
 log
 temp/*
 temp
-cmake-build-debug
-cmake-build-release
+cmake-build-*
 .idea
 .vscode
 www/default/upload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,32 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
 
+cmake_policy(SET CMP0048 NEW)
+
+set(ENABLE_VCPKG OFF CACHE BOOL "choose ON to enable")
+set(ENABLE_BOOST OFF CACHE BOOL "choose ON to enable")
+set(ENABLE_GD OFF CACHE BOOL "choose ON to enable")
+
+if (ENABLE_GD STREQUAL "ON")
+    list(FIND VCPKG_MANIFEST_FEATURES "gd" index)
+    if (index EQUAL -1)
+        message(STATUS "Auto append features: gd")
+        list(APPEND VCPKG_MANIFEST_FEATURES "gd")
+    endif ()
+endif ()
+
+if (ENABLE_BOOST STREQUAL "ON")
+    list(FIND VCPKG_MANIFEST_FEATURES "boost" index)
+    if (index EQUAL -1)
+        message(STATUS "Auto append features: boost")
+        list(APPEND VCPKG_MANIFEST_FEATURES "boost")
+    endif ()
+endif ()
+
 PROJECT(Paozhu_web_framework)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(mode "CMAKE_BUILD_TYPE")
-
-set(ENABLE_VCPKG OFF CACHE BOOL "choose ON to enable")
-
-set(ENABLE_BOOST OFF CACHE BOOL "choose ON to enable")
-set(ENABLE_GD OFF CACHE BOOL "choose ON to enable")
 
 set(BOOST_OPEN "  ")
 set(GD_OPEN " ")
@@ -178,23 +195,24 @@ if (ENABLE_VCPKG)
     target_include_directories(paozhu_cli PUBLIC ${MYSQL_ROOT_DIR}/mysql)
 
     if (ENABLE_GD STREQUAL "ON")
-        find_package(PkgConfig REQUIRED)
+        find_package(PkgConfig)
         pkg_check_modules(LIBGD REQUIRED IMPORTED_TARGET gdlib)
         target_link_libraries(paozhu PkgConfig::LIBGD)
+
+        find_path(QRENCODE_INCLUDE_DIR NAMES qrencode.h)
+        find_library(QRENCODE_LIBRARY_RELEASE qrencode)
+        # find_library(QRENCODE_LIBRARY_DEBUG qrencoded)
+        # set(QRENCODE_LIBRARIES optimized ${QRENCODE_LIBRARY_RELEASE} debug ${QRENCODE_LIBRARY_DEBUG})
+        target_include_directories(paozhu PRIVATE ${QRENCODE_INCLUDE_DIR})
+        target_link_libraries(paozhu ${QRENCODE_LIBRARY_RELEASE})
+        MESSAGE(STATUS ${QRENCODE_LIBRARY_RELEASE})
+
+        find_package(PNG REQUIRED)
+        target_link_libraries(paozhu PNG::PNG)
+
+        find_package(Freetype REQUIRED)
+        target_link_libraries(paozhu Freetype::Freetype)
     endif ()
-
-    find_path(QRENCODE_INCLUDE_DIR NAMES qrencode.h)
-    find_library(QRENCODE_LIBRARY_RELEASE qrencode)
-    # find_library(QRENCODE_LIBRARY_DEBUG qrencoded)
-    # set(QRENCODE_LIBRARIES optimized ${QRENCODE_LIBRARY_RELEASE} debug ${QRENCODE_LIBRARY_DEBUG})
-    target_include_directories(paozhu PRIVATE ${QRENCODE_INCLUDE_DIR})
-    target_link_libraries(paozhu ${QRENCODE_LIBRARIES})
-
-    find_package(PNG REQUIRED)
-    target_link_libraries(paozhu PNG::PNG)
-
-    find_package(Freetype REQUIRED)
-    target_link_libraries(paozhu Freetype::Freetype)
 
     find_package(unofficial-brotli CONFIG REQUIRED)
     target_link_libraries(paozhu unofficial::brotli::brotlidec unofficial::brotli::brotlienc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
 
+set(ENV{http_proxy} http://192.168.204.1:7890)
+set(ENV{https_proxy} http://192.168.204.1:7890)
+
 PROJECT(Paozhu_web_framework)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -201,48 +204,51 @@ if(ZLIB_FOUND)
   target_link_libraries(paozhu z)
 endif()
 
-find_path(MYSQL_ROOT_DIR mysql)
-MESSAGE( STATUS "MYSQL_ROOT_DIR = ${MYSQL_ROOT_DIR} ")
-find_package_handle_standard_args(mysql REQUIRED_VARS MYSQL_ROOT_DIR)
+find_package(libmysql REQUIRED)
 
-FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
-  /usr/local/include/mysql
-  /usr/include/mysql
-  /usr/local/mysql/include
-)
-SET(MYSQL_NAMES mysqlclient)
-FIND_LIBRARY(MYSQL_LIBRARY
-  NAMES ${MYSQL_NAMES}
-  PATHS /usr/lib /usr/local/lib /usr/local/mysql/lib
-  PATH_SUFFIXES mysql
-)
+# find_path(MYSQL_ROOT_DIR mysql)
+# MESSAGE( STATUS "MYSQL_ROOT_DIR = ${MYSQL_ROOT_DIR} ")
+# find_package_handle_standard_args(mysql REQUIRED_VARS MYSQL_ROOT_DIR)
+#
+# FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
+#   /usr/local/include/mysql
+#   /usr/include/mysql
+#   /usr/local/mysql/include
+# )
+# SET(MYSQL_NAMES mysqlclient)
+# FIND_LIBRARY(MYSQL_LIBRARY
+#   NAMES ${MYSQL_NAMES}
+#   PATHS /usr/lib /usr/local/lib /usr/local/mysql/lib
+#   PATH_SUFFIXES mysql
+# )
+#
+# IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+#   SET(MYSQL_FOUND TRUE)
+#   SET( MYSQL_LIBRARIES ${MYSQL_LIBRARY} )
+# ELSE (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+#   SET(MYSQL_FOUND FALSE)
+#   SET( MYSQL_LIBRARIES )
+# ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+#
+# IF (MYSQL_FOUND)
+#   IF (NOT MYSQL_FIND_QUIETLY)
+#     MESSAGE(STATUS "Found MySQL: ${MYSQL_LIBRARY}")
+#   ENDIF (NOT MYSQL_FIND_QUIETLY)
+# ELSE (MYSQL_FOUND)
+#   IF (MYSQL_FIND_REQUIRED)
+#     MESSAGE(STATUS "Looked for MySQL libraries named ${MYSQL_NAMES}.")
+#     MESSAGE(FATAL_ERROR "Could NOT find MySQL library")
+#   ENDIF (MYSQL_FIND_REQUIRED)
+# ENDIF (MYSQL_FOUND)
+#
+# target_include_directories(paozhu PUBLIC ${MYSQL_INCLUDE_DIR})
+# target_link_libraries(paozhu ${MYSQL_LIBRARY})
+#
+# target_include_directories(paozhu_cli PUBLIC ${MYSQL_INCLUDE_DIR})
+# target_link_libraries(paozhu_cli ${MYSQL_LIBRARY})
 
-IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-  SET(MYSQL_FOUND TRUE)
-  SET( MYSQL_LIBRARIES ${MYSQL_LIBRARY} )
-ELSE (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-  SET(MYSQL_FOUND FALSE)
-  SET( MYSQL_LIBRARIES )
-ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-
-IF (MYSQL_FOUND)
-  IF (NOT MYSQL_FIND_QUIETLY)
-    MESSAGE(STATUS "Found MySQL: ${MYSQL_LIBRARY}")
-  ENDIF (NOT MYSQL_FIND_QUIETLY)
-ELSE (MYSQL_FOUND)
-  IF (MYSQL_FIND_REQUIRED)
-    MESSAGE(STATUS "Looked for MySQL libraries named ${MYSQL_NAMES}.")
-    MESSAGE(FATAL_ERROR "Could NOT find MySQL library")
-  ENDIF (MYSQL_FIND_REQUIRED)
-ENDIF (MYSQL_FOUND)
-
-target_include_directories(paozhu PUBLIC ${MYSQL_INCLUDE_DIR})
-target_link_libraries(paozhu ${MYSQL_LIBRARY})
-
-target_include_directories(paozhu_cli PUBLIC ${MYSQL_INCLUDE_DIR})
-target_link_libraries(paozhu_cli ${MYSQL_LIBRARY})
-
-
+target_link_libraries(paozhu ${MYSQL_LIBRARIES})
+target_link_libraries(paozhu_cli ${MYSQL_LIBRARIES})
 
 if(ENABLE_GD STREQUAL "ON")
 message("---ENABLE_GD-----")
@@ -353,25 +359,32 @@ find_library(BRDEC_LIB_DIR
 INCLUDE_DIRECTORIES("${BROTLI_ROOT_DIR}/include")
 link_directories("${BROTLI_ROOT_DIR}/lib")
 
-if(NOT BR_LIB_DIR)
-message(FATAL_ERROR
-"Brotli Library  NOT FOUND! please install . "
-)
-endif()
+find_package(PkgConfig)
+pkg_check_modules(LIBGD REQUIRED IMPORTED_TARGET gdlib)
 
-message(STATUS "Brotli at: ${BR_LIB_DIR}")
-target_link_libraries(paozhu ${BR_LIB_DIR})
- 
+# if(NOT BR_LIB_DIR)
+# message(FATAL_ERROR
+# "Brotli Library  NOT FOUND! please install . "
+# )
+# endif()
+#
+# message(STATUS "Brotli at: ${BR_LIB_DIR}")
+# target_link_libraries(paozhu ${BR_LIB_DIR})
 
-if(NOT BRDEC_LIB_DIR)
-message(FATAL_ERROR
-"Brotli Library  NOT FOUND! please install . "
-)
-endif()
+target_link_libraries(paozhu PkgConfig::LIBGD)
 
-message(STATUS "Brotli at: ${BRDEC_LIB_DIR}")
-target_link_libraries(paozhu ${BRDEC_LIB_DIR})
+find_package(unofficial-brotli CONFIG REQUIRED)
 
+# if(NOT BRDEC_LIB_DIR)
+# message(FATAL_ERROR
+# "Brotli Library  NOT FOUND! please install . "
+# )
+# endif()
+#
+# message(STATUS "Brotli at: ${BRDEC_LIB_DIR}")
+# target_link_libraries(paozhu ${BRDEC_LIB_DIR})
+
+target_link_libraries(paozhu unofficial::brotli::brotlidec unofficial::brotli::brotlienc)
 
 message("Compile framework mode")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,42 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
 
-set(ENV{http_proxy} http://192.168.204.1:7890)
-set(ENV{https_proxy} http://192.168.204.1:7890)
-
 PROJECT(Paozhu_web_framework)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(mode "CMAKE_BUILD_TYPE")
- 
+
+set(ENABLE_VCPKG OFF CACHE BOOL "choose ON to enable")
+
 set(ENABLE_BOOST OFF CACHE BOOL "choose ON to enable")
 set(ENABLE_GD OFF CACHE BOOL "choose ON to enable")
 
 set(BOOST_OPEN "  ")
 set(GD_OPEN " ")
 
-if(ENABLE_BOOST STREQUAL "ON")  
+if(ENABLE_BOOST STREQUAL "ON")
   message("ENABLE_BOOST")
   set(BOOST_OPEN " -DENABLE_BOOST ")
 endif()
 
-if(ENABLE_GD STREQUAL "ON")  
+if(ENABLE_GD STREQUAL "ON")
     message("ENABLE_GD")
     set(GD_OPEN " -DENABLE_GD ")
 endif()
 
 set(sys_so_path "/usr/lib64")
 
-if (IS_DIRECTORY "/usr/lib/x86_64-linux-gnu") 
+if (IS_DIRECTORY "/usr/lib/x86_64-linux-gnu")
   set(sys_so_path "/usr/lib/x86_64-linux-gnu")
 endif()
 
-if(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))  
+if(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
     message("Debug mode:${CMAKE_C_FLAGS_DEBUG}")
     set(CMAKE_CXX_FLAGS " -Wall -Wextra -pthread  -g -fsanitize=address  -DASIO_STANDALONE -DDEBUG ${BOOST_OPEN} ${GD_OPEN} -I/usr/local/include -I/usr/local/mysql/include   -I/usr/include -I/usr/include/mysql " )
 
 
-elseif(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Release")) 
+elseif(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra -O3")
     message("Release mode:${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS "  -pthread  -DASIO_STANDALONE ${BOOST_OPEN} ${GD_OPEN}  -I/usr/local/include -I/usr/local/mysql/include -I/usr/include -I/usr/include/mysql  " )
@@ -47,7 +46,7 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
     message("Debug mode")
     set(CMAKE_CXX_FLAGS " -Wall -Wextra -pthread  -g -fsanitize=address  -DASIO_STANDALONE -DDEBUG ${BOOST_OPEN} ${GD_OPEN} -I/usr/local/include -I/usr/local/mysql/include   -I/usr/include  -I/usr/include/mysql  " )
-  
+
 endif()
 
 
@@ -71,7 +70,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/viewsrc/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/websockets/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-file(REMOVE_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty)
+  file(REMOVE_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty)
+endif ()
 #EXECUTE_PROCESS(COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty)
 set(PAOZHU_PRE paozhu_pre)
 add_executable(${PAOZHU_PRE} ${CMAKE_CURRENT_SOURCE_DIR}/vendor/httpcli/autopickmethod.cpp ${CMAKE_CURRENT_SOURCE_DIR}/vendor/httpserver/src/md5.cpp)
@@ -126,7 +127,7 @@ add_executable(paozhu_cli ${CMAKE_CURRENT_SOURCE_DIR}/vendor/httpcli/http_cli.cp
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
 
-if(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Release")) 
+if(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
   add_executable(paozhu ${CMAKE_CURRENT_SOURCE_DIR}/test/testdaemon.cpp ${common_list} ${viewsrc_list} ${FRAMEWORK_CPP_PATH} ${orm_list} ${reflect_list} ${src_list} ${source_list} ${controller_list})
 else()
   add_executable(paozhu ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp ${common_list} ${viewsrc_list} ${FRAMEWORK_CPP_PATH} ${orm_list} ${reflect_list} ${src_list} ${source_list} ${controller_list})
@@ -141,16 +142,61 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
     COMMAND echo "-- controls method --"
     COMMAND ${PAOZHU_PRE} ${CMAKE_CURRENT_SOURCE_DIR}/
-    COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty
+    COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/bin/paozhu_empty
     )
 
+if (ENABLE_VCPKG)
+    add_compile_definitions(ENABLE_VCPKG)
+    find_package(asio CONFIG REQUIRED)
+    target_link_libraries(paozhu asio::asio)
+
+    set(Boost_NO_WARN_NEW_VERSIONS ON)
+    find_package(Boost REQUIRED COMPONENTS filesystem coroutine)
+    target_link_libraries(paozhu Boost::boost Boost::filesystem Boost::coroutine)
+
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(paozhu OpenSSL::Crypto OpenSSL::SSL)
+
+    find_package(ZLIB REQUIRED)
+    target_link_libraries(paozhu ZLIB::ZLIB)
+
+    find_package(libmysql REQUIRED)
+    find_path(MYSQL_ROOT_DIR mysql)
+    target_link_libraries(paozhu ${MYSQL_LIBRARIES})
+    target_link_libraries(paozhu_cli ${MYSQL_LIBRARIES})
+    target_include_directories(paozhu PUBLIC ${MYSQL_ROOT_DIR}/mysql)
+    target_include_directories(paozhu_cli PUBLIC ${MYSQL_ROOT_DIR}/mysql)
+
+    if (ENABLE_GD STREQUAL "ON")
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(LIBGD REQUIRED IMPORTED_TARGET gdlib)
+        target_link_libraries(paozhu PkgConfig::LIBGD)
+    endif ()
+
+    find_path(QRENCODE_INCLUDE_DIR NAMES qrencode.h)
+    find_library(QRENCODE_LIBRARY_RELEASE qrencode)
+    # find_library(QRENCODE_LIBRARY_DEBUG qrencoded)
+    # set(QRENCODE_LIBRARIES optimized ${QRENCODE_LIBRARY_RELEASE} debug ${QRENCODE_LIBRARY_DEBUG})
+    target_include_directories(paozhu PRIVATE ${QRENCODE_INCLUDE_DIR})
+    target_link_libraries(paozhu ${QRENCODE_LIBRARIES})
+
+    find_package(PNG REQUIRED)
+    target_link_libraries(paozhu PNG::PNG)
+
+    find_package(Freetype REQUIRED)
+    target_link_libraries(paozhu Freetype::Freetype)
+
+    find_package(unofficial-brotli CONFIG REQUIRED)
+    target_link_libraries(paozhu unofficial::brotli::brotlidec unofficial::brotli::brotlienc)
+else ()
+
 if(USE_STANDALONE_ASIO)
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 set(ASIO_PATH "/usr/local/opt/asio/include" "/usr/local/include")
 else()
 set(ASIO_PATH ${CMAKE_CURRENT_SOURCE_DIR}/asio "/usr/include")
 endif()
-  
+
     target_compile_definitions(paozhu INTERFACE ASIO_STANDALONE)
     find_path(ASIO_PATH asio.hpp)
     message(state " Standalone Asio found: " ${ASIO_PATH})
@@ -165,7 +211,7 @@ endif()
 endif()
 
 
-if(ENABLE_BOOST STREQUAL "ON")  
+if(ENABLE_BOOST STREQUAL "ON")
 message("---ENABLE_BOOST-----")
 find_package(Boost REQUIRED
              COMPONENTS system filesystem)
@@ -177,22 +223,22 @@ if(Boost_FOUND)
     MESSAGE( STATUS "Boost_LIB_VERSION = ${Boost_LIB_VERSION}")
     link_directories(${Boost_LIBRARY_DIRS})
     target_link_libraries (paozhu ${Boost_LIBRARIES})
-endif()        
+endif()
 
 endif()
 
 
 find_package(OpenSSL REQUIRED)
- 
+
 if(OPENSSL_FOUND)
- 
+
   message(STATUS "OPENSSL_VERSION = ${OPENSSL_VERSION}")
   message(STATUS "OPENSSL_SSL_LIBRARY = ${OPENSSL_SSL_LIBRARY}")
   message(STATUS "OPENSSL_CRYPTO_LIBRARY = ${OPENSSL_CRYPTO_LIBRARY}")
-  message(STATUS "OPENSSL_INCLUDE_DIR = ${OPENSSL_INCLUDE_DIR}")  
+  message(STATUS "OPENSSL_INCLUDE_DIR = ${OPENSSL_INCLUDE_DIR}")
   INCLUDE_DIRECTORIES("${OPENSSL_INCLUDE_DIR}")
-  target_link_libraries (paozhu ${OPENSSL_SSL_LIBRARY})  
-  target_link_libraries (paozhu ${OPENSSL_CRYPTO_LIBRARY})  
+  target_link_libraries (paozhu ${OPENSSL_SSL_LIBRARY})
+  target_link_libraries (paozhu ${OPENSSL_CRYPTO_LIBRARY})
 endif()
 
 
@@ -204,56 +250,53 @@ if(ZLIB_FOUND)
   target_link_libraries(paozhu z)
 endif()
 
-find_package(libmysql REQUIRED)
+find_path(MYSQL_ROOT_DIR mysql)
+MESSAGE( STATUS "MYSQL_ROOT_DIR = ${MYSQL_ROOT_DIR} ")
+find_package_handle_standard_args(mysql REQUIRED_VARS MYSQL_ROOT_DIR)
 
-# find_path(MYSQL_ROOT_DIR mysql)
-# MESSAGE( STATUS "MYSQL_ROOT_DIR = ${MYSQL_ROOT_DIR} ")
-# find_package_handle_standard_args(mysql REQUIRED_VARS MYSQL_ROOT_DIR)
-#
-# FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
-#   /usr/local/include/mysql
-#   /usr/include/mysql
-#   /usr/local/mysql/include
-# )
-# SET(MYSQL_NAMES mysqlclient)
-# FIND_LIBRARY(MYSQL_LIBRARY
-#   NAMES ${MYSQL_NAMES}
-#   PATHS /usr/lib /usr/local/lib /usr/local/mysql/lib
-#   PATH_SUFFIXES mysql
-# )
-#
-# IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-#   SET(MYSQL_FOUND TRUE)
-#   SET( MYSQL_LIBRARIES ${MYSQL_LIBRARY} )
-# ELSE (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-#   SET(MYSQL_FOUND FALSE)
-#   SET( MYSQL_LIBRARIES )
-# ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-#
-# IF (MYSQL_FOUND)
-#   IF (NOT MYSQL_FIND_QUIETLY)
-#     MESSAGE(STATUS "Found MySQL: ${MYSQL_LIBRARY}")
-#   ENDIF (NOT MYSQL_FIND_QUIETLY)
-# ELSE (MYSQL_FOUND)
-#   IF (MYSQL_FIND_REQUIRED)
-#     MESSAGE(STATUS "Looked for MySQL libraries named ${MYSQL_NAMES}.")
-#     MESSAGE(FATAL_ERROR "Could NOT find MySQL library")
-#   ENDIF (MYSQL_FIND_REQUIRED)
-# ENDIF (MYSQL_FOUND)
-#
-# target_include_directories(paozhu PUBLIC ${MYSQL_INCLUDE_DIR})
-# target_link_libraries(paozhu ${MYSQL_LIBRARY})
-#
-# target_include_directories(paozhu_cli PUBLIC ${MYSQL_INCLUDE_DIR})
-# target_link_libraries(paozhu_cli ${MYSQL_LIBRARY})
+FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
+  /usr/local/include/mysql
+  /usr/include/mysql
+  /usr/local/mysql/include
+)
+SET(MYSQL_NAMES mysqlclient)
+FIND_LIBRARY(MYSQL_LIBRARY
+  NAMES ${MYSQL_NAMES}
+  PATHS /usr/lib /usr/local/lib /usr/local/mysql/lib
+  PATH_SUFFIXES mysql
+)
 
-target_link_libraries(paozhu ${MYSQL_LIBRARIES})
-target_link_libraries(paozhu_cli ${MYSQL_LIBRARIES})
+IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+  SET(MYSQL_FOUND TRUE)
+  SET( MYSQL_LIBRARIES ${MYSQL_LIBRARY} )
+ELSE (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+  SET(MYSQL_FOUND FALSE)
+  SET( MYSQL_LIBRARIES )
+ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+
+IF (MYSQL_FOUND)
+  IF (NOT MYSQL_FIND_QUIETLY)
+    MESSAGE(STATUS "Found MySQL: ${MYSQL_LIBRARY}")
+  ENDIF (NOT MYSQL_FIND_QUIETLY)
+ELSE (MYSQL_FOUND)
+  IF (MYSQL_FIND_REQUIRED)
+    MESSAGE(STATUS "Looked for MySQL libraries named ${MYSQL_NAMES}.")
+    MESSAGE(FATAL_ERROR "Could NOT find MySQL library")
+  ENDIF (MYSQL_FIND_REQUIRED)
+ENDIF (MYSQL_FOUND)
+
+target_include_directories(paozhu PUBLIC ${MYSQL_INCLUDE_DIR})
+target_link_libraries(paozhu ${MYSQL_LIBRARY})
+
+target_include_directories(paozhu_cli PUBLIC ${MYSQL_INCLUDE_DIR})
+target_link_libraries(paozhu_cli ${MYSQL_LIBRARY})
+
+
 
 if(ENABLE_GD STREQUAL "ON")
 message("---ENABLE_GD-----")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(GD_ROOT_DIR "/usr/local/opt/gd/lib")
 else()
   set(GD_ROOT_DIR "${sys_so_path}")
@@ -275,7 +318,7 @@ endif()
 
 message(STATUS "GD Graphics Library  at: ${GD_LIB_DIR}")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 set(QR_ROOT_DIR "/usr/local/opt/qrencode/lib")
 else()
 set(QR_ROOT_DIR "${sys_so_path}")
@@ -304,7 +347,7 @@ link_directories("${GD_ROOT_DIR}/lib")
 target_link_libraries(paozhu ${GD_LIB_DIR})
 target_link_libraries(paozhu ${QR_LIB_DIR})
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 set(PNG_ROOT_DIR "/usr/local/opt/libpng/lib")
 else()
 set(PNG_ROOT_DIR "${sys_so_path}")
@@ -317,7 +360,7 @@ find_library(PNG_LIB_DIR
 )
 target_link_libraries(paozhu ${PNG_LIB_DIR})
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(FREETYPE_ROOT_DIR "/usr/local/opt/freetype/lib")
 else()
   set(FREETYPE_ROOT_DIR "${sys_so_path}")
@@ -332,7 +375,7 @@ target_link_libraries(paozhu ${FREETYPE_LIB_DIR})
 #end ENABLE_GD
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(BROTLI_ROOT_DIR "/usr/local/opt/brotli/lib")
 else()
   set(BROTLI_ROOT_DIR "${sys_so_path}")
@@ -359,34 +402,28 @@ find_library(BRDEC_LIB_DIR
 INCLUDE_DIRECTORIES("${BROTLI_ROOT_DIR}/include")
 link_directories("${BROTLI_ROOT_DIR}/lib")
 
-find_package(PkgConfig)
-pkg_check_modules(LIBGD REQUIRED IMPORTED_TARGET gdlib)
+if(NOT BR_LIB_DIR)
+message(FATAL_ERROR
+"Brotli Library  NOT FOUND! please install . "
+)
+endif()
 
-# if(NOT BR_LIB_DIR)
-# message(FATAL_ERROR
-# "Brotli Library  NOT FOUND! please install . "
-# )
-# endif()
-#
-# message(STATUS "Brotli at: ${BR_LIB_DIR}")
-# target_link_libraries(paozhu ${BR_LIB_DIR})
+message(STATUS "Brotli at: ${BR_LIB_DIR}")
+target_link_libraries(paozhu ${BR_LIB_DIR})
 
-target_link_libraries(paozhu PkgConfig::LIBGD)
 
-find_package(unofficial-brotli CONFIG REQUIRED)
+if(NOT BRDEC_LIB_DIR)
+message(FATAL_ERROR
+"Brotli Library  NOT FOUND! please install . "
+)
+endif()
 
-# if(NOT BRDEC_LIB_DIR)
-# message(FATAL_ERROR
-# "Brotli Library  NOT FOUND! please install . "
-# )
-# endif()
-#
-# message(STATUS "Brotli at: ${BRDEC_LIB_DIR}")
-# target_link_libraries(paozhu ${BRDEC_LIB_DIR})
+message(STATUS "Brotli at: ${BRDEC_LIB_DIR}")
+target_link_libraries(paozhu ${BRDEC_LIB_DIR})
 
-target_link_libraries(paozhu unofficial::brotli::brotlidec unofficial::brotli::brotlienc)
 
 message("Compile framework mode")
 
 target_link_libraries(paozhu  m  dl)
 
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,11 @@ endif()
 if(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
     message("Debug mode:${CMAKE_C_FLAGS_DEBUG}")
-    set(CMAKE_CXX_FLAGS " -Wall -Wextra -pthread  -g -fsanitize=address  -DASIO_STANDALONE -DDEBUG ${BOOST_OPEN} ${GD_OPEN} -I/usr/local/include -I/usr/local/mysql/include   -I/usr/include -I/usr/include/mysql " )
+    set(CMAKE_CXX_FLAGS " -Wall -Wextra -pthread  -g  -DASIO_STANDALONE -DDEBUG ${BOOST_OPEN} ${GD_OPEN} -I/usr/local/include -I/usr/local/mysql/include   -I/usr/include -I/usr/include/mysql " )
+
+    if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    endif ()
 
 
 elseif(${mode} AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
@@ -47,6 +51,9 @@ else()
     message("Debug mode")
     set(CMAKE_CXX_FLAGS " -Wall -Wextra -pthread  -g -fsanitize=address  -DASIO_STANDALONE -DDEBUG ${BOOST_OPEN} ${GD_OPEN} -I/usr/local/include -I/usr/local/mysql/include   -I/usr/include  -I/usr/include/mysql  " )
 
+    if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    endif ()
 endif()
 
 
@@ -160,10 +167,13 @@ if (ENABLE_VCPKG)
     find_package(ZLIB REQUIRED)
     target_link_libraries(paozhu ZLIB::ZLIB)
 
-    find_package(libmysql REQUIRED)
+    # find_package(libmysql REQUIRED)
+    find_package(unofficial-libmariadb CONFIG REQUIRED)
     find_path(MYSQL_ROOT_DIR mysql)
-    target_link_libraries(paozhu ${MYSQL_LIBRARIES})
-    target_link_libraries(paozhu_cli ${MYSQL_LIBRARIES})
+    # target_link_libraries(paozhu ${MYSQL_LIBRARIES})
+    # target_link_libraries(paozhu_cli ${MYSQL_LIBRARIES})
+    target_link_libraries(paozhu unofficial::libmariadb)
+    target_link_libraries(paozhu_cli unofficial::libmariadb)
     target_include_directories(paozhu PUBLIC ${MYSQL_ROOT_DIR}/mysql)
     target_include_directories(paozhu_cli PUBLIC ${MYSQL_ROOT_DIR}/mysql)
 
@@ -426,4 +436,9 @@ message("Compile framework mode")
 
 target_link_libraries(paozhu  m  dl)
 
+endif ()
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+   target_link_libraries(paozhu ws2_32)
+   target_link_libraries(paozhu_cli ws2_32)
 endif ()

--- a/common/autocontrolmethod.hpp
+++ b/common/autocontrolmethod.hpp
@@ -8,33 +8,33 @@
 
 #include "httppeer.h" 
 
-#include "testhttpclient.h"
-#include "testmysqlinsert.h"
-#include "testrestfulpath.h"
-#include "testmodelfromjson.h"
-#include "teststrip_html.h"
-#include "testrand.h"
-#include "testormcache.h"
-#include "testsendmail.h"
 #include "admin/articles.h"
-#include "admin/topics.h"
 #include "admin/main.h"
-#include "testformpost.h"
-#include "testqrcode.h"
-#include "imageapi.h"
-#include "testpzcache.h"
-#include "testhello.h"
-#include "testcmake.h"
-#include "testjsonreflect.h"
-#include "testaddclienttask.h"
-#include "testormclient.h"
-#include "testcommit.h"
+#include "admin/topics.h"
 #include "apicrudtest.h"
-#include "testcowaitclient.h"
-#include "testcors.h"
-#include "testsqltuple.h"
-#include "testsessionid.h"
 #include "devcors.h"
+#include "imageapi.h"
+#include "testaddclienttask.h"
+#include "testcmake.h"
+#include "testcommit.h"
+#include "testcors.h"
+#include "testcowaitclient.h"
+#include "testformpost.h"
+#include "testhello.h"
+#include "testhttpclient.h"
+#include "testjsonreflect.h"
+#include "testmodelfromjson.h"
+#include "testmysqlinsert.h"
+#include "testormcache.h"
+#include "testormclient.h"
+#include "testpzcache.h"
+#include "testqrcode.h"
+#include "testrand.h"
+#include "testrestfulpath.h"
+#include "testsendmail.h"
+#include "testsessionid.h"
+#include "testsqltuple.h"
+#include "teststrip_html.h"
 
 
 namespace http
@@ -43,48 +43,6 @@ namespace http
   {
     struct regmethold_t temp;
 
-		temp.pre = nullptr;
-		temp.regfun = testhttpclient_get_body;
-		methodcallback.emplace("testhttpclient1",temp);
-		temp.pre = nullptr;
-		temp.regfun = testhttpclient_get_timebody;
-		methodcallback.emplace("testhttpclient3",temp);
-		temp.pre = nullptr;
-		temp.regfun = testhttpclient_get_file;
-		methodcallback.emplace("testhttpclient2",temp);
-		temp.pre = nullptr;
-		temp.regfun = testmysqlinsert;
-		methodcallback.emplace("minsert",temp);
-		temp.pre = nullptr;
-		temp.regfun = testmysqlpagebar;
-		methodcallback.emplace("mpagebar",temp);
-		temp.pre = nullptr;
-		temp.regfun = testrestfulpath;
-		methodcallback.emplace("user/info",temp);
-		temp.pre = nullptr;
-		temp.regfun = testrestfulprofilepath;
-		methodcallback.emplace("user/profile",temp);
-		temp.pre = nullptr;
-		temp.regfun = testmodelfromjson;
-		methodcallback.emplace("mfromjson",temp);
-		temp.pre = nullptr;
-		temp.regfun = teststrip_html;
-		methodcallback.emplace("teststrip_html",temp);
-		temp.pre = nullptr;
-		temp.regfun = testrand;
-		methodcallback.emplace("testrand",temp);
-		temp.pre = nullptr;
-		temp.regfun = testormcache;
-		methodcallback.emplace("testormcache",temp);
-		temp.pre = nullptr;
-		temp.regfun = testormcacheb;
-		methodcallback.emplace("testormcacheb",temp);
-		temp.pre = nullptr;
-		temp.regfun = testormcachec;
-		methodcallback.emplace("testormcachec",temp);
-		temp.pre = nullptr;
-		temp.regfun = testsendmaildo;
-		methodcallback.emplace("testsendmaildo",temp);
 		temp.pre = nullptr;
 		temp.regfun = admin_addarticle;
 		methodcallback.emplace("admin/addarticle",temp);
@@ -106,24 +64,6 @@ namespace http
 		temp.pre = nullptr;
 		temp.regfun = admin_listarticle;
 		methodcallback.emplace("admin/listarticle",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_addtopic;
-		methodcallback.emplace("admin/addtopic",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_edittopic;
-		methodcallback.emplace("admin/edittopic",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_martopic;
-		methodcallback.emplace("admin/martopic",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_addtopicpost;
-		methodcallback.emplace("admin/addtopicpost",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_deletetopic;
-		methodcallback.emplace("admin/deletetopic",temp);
-		temp.pre = nullptr;
-		temp.regfun = admin_edittopicpost;
-		methodcallback.emplace("admin/edittopicpost",temp);
 		temp.pre = nullptr;
 		temp.regfun = admin_main;
 		methodcallback.emplace("admin/main",temp);
@@ -149,65 +89,23 @@ namespace http
 		temp.regfun = admin_editpwdpost;
 		methodcallback.emplace("admin/editpwdpost",temp);
 		temp.pre = nullptr;
-		temp.regfun = testurlencoded;
-		methodcallback.emplace("tformpost",temp);
+		temp.regfun = admin_addtopic;
+		methodcallback.emplace("admin/addtopic",temp);
 		temp.pre = nullptr;
-		temp.regfun = testformmultipart;
-		methodcallback.emplace("tfilepost",temp);
+		temp.regfun = admin_edittopic;
+		methodcallback.emplace("admin/edittopic",temp);
 		temp.pre = nullptr;
-		temp.regfun = testformjsonpost;
-		methodcallback.emplace("tjsonpost",temp);
+		temp.regfun = admin_martopic;
+		methodcallback.emplace("admin/martopic",temp);
 		temp.pre = nullptr;
-		temp.regfun = testformxmlpost;
-		methodcallback.emplace("txmlupload",temp);
+		temp.regfun = admin_addtopicpost;
+		methodcallback.emplace("admin/addtopicpost",temp);
 		temp.pre = nullptr;
-		temp.regfun = testuploadpostfile;
-		methodcallback.emplace("addpostfile",temp);
+		temp.regfun = admin_deletetopic;
+		methodcallback.emplace("admin/deletetopic",temp);
 		temp.pre = nullptr;
-		temp.regfun = testqrcode;
-		methodcallback.emplace("testqrcode",temp);
-		temp.pre = nullptr;
-		temp.regfun = imageapi_gateway;
-		methodcallback.emplace("imageapi/gateway",temp);
-		temp.pre = nullptr;
-		temp.regfun = imageapi_upload;
-		methodcallback.emplace("imageapi/upload",temp);
-		temp.pre = nullptr;
-		temp.regfun = testpzcache;
-		methodcallback.emplace("testcache",temp);
-		temp.pre = nullptr;
-		temp.regfun = testshowcache;
-		methodcallback.emplace("testshowcache",temp);
-		temp.pre = nullptr;
-		temp.regfun = testhello;
-		methodcallback.emplace("hello",temp);
-		temp.pre = nullptr;
-		temp.regfun = testhellobusy;
-		methodcallback.emplace("hellobusy",temp);
-		temp.pre = nullptr;
-		temp.regfun = testcmake;
-		methodcallback.emplace("ccmake",temp);
-		temp.pre = nullptr;
-		temp.regfun = testcauto;
-		methodcallback.emplace("ccauto",temp);
-		temp.pre = nullptr;
-		temp.regfun = testjsonreflect;
-		methodcallback.emplace("testjsonreflect",temp);
-		temp.pre = nullptr;
-		temp.regfun = testaddclienttaskpre;
-		methodcallback.emplace("testnotaddclienttaskpre",temp);
-		temp.pre = testaddclienttaskpre;
-		temp.regfun = testaddclienttask;
-		methodcallback.emplace("testaddclienttask",temp);
-		temp.pre = nullptr;
-		temp.regfun = testexecuteclienttask;
-		methodcallback.emplace("executeclienttask",temp);
-		temp.pre = nullptr;
-		temp.regfun = testormclient;
-		methodcallback.emplace("testormclient",temp);
-		temp.pre = nullptr;
-		temp.regfun = testcommit;
-		methodcallback.emplace("testcommit",temp);
+		temp.regfun = admin_edittopicpost;
+		methodcallback.emplace("admin/edittopicpost",temp);
 		temp.pre = nullptr;
 		temp.regfun = pxapidepartmentsaddpost;
 		methodcallback.emplace("api/departments/addpost",temp);
@@ -220,6 +118,39 @@ namespace http
 		temp.pre = nullptr;
 		temp.regfun = pxapipagesdepartlist;
 		methodcallback.emplace("api/departments/deletedep",temp);
+		temp.pre = nullptr;
+		temp.regfun = api_dev_hostcors;
+		methodcallback.emplace("api/dev/hostcors",temp);
+		temp.pre = nullptr;
+		temp.regfun = imageapi_gateway;
+		methodcallback.emplace("imageapi/gateway",temp);
+		temp.pre = nullptr;
+		temp.regfun = imageapi_upload;
+		methodcallback.emplace("imageapi/upload",temp);
+		temp.pre = nullptr;
+		temp.regfun = testaddclienttaskpre;
+		methodcallback.emplace("testnotaddclienttaskpre",temp);
+		temp.pre = testaddclienttaskpre;
+		temp.regfun = testaddclienttask;
+		methodcallback.emplace("testaddclienttask",temp);
+		temp.pre = nullptr;
+		temp.regfun = testexecuteclienttask;
+		methodcallback.emplace("executeclienttask",temp);
+		temp.pre = nullptr;
+		temp.regfun = testcmake;
+		methodcallback.emplace("ccmake",temp);
+		temp.pre = nullptr;
+		temp.regfun = testcauto;
+		methodcallback.emplace("ccauto",temp);
+		temp.pre = nullptr;
+		temp.regfun = testcommit;
+		methodcallback.emplace("testcommit",temp);
+		temp.pre = nullptr;
+		temp.regfun = testcors;
+		methodcallback.emplace("api/user/message",temp);
+		temp.pre = nullptr;
+		temp.regfun = testcorssimple;
+		methodcallback.emplace("api/user/info",temp);
 		temp.pre = nullptr;
 		temp.regfun = testhttpclient_cowait_php;
 		methodcallback.emplace("testcowaitclient4",temp);
@@ -236,14 +167,80 @@ namespace http
 		temp.regfun = testhttpclient_cowait_spawn;
 		methodcallback.emplace("testcowaitclient3",temp);
 		temp.pre = nullptr;
-		temp.regfun = testcors;
-		methodcallback.emplace("api/user/message",temp);
+		temp.regfun = testurlencoded;
+		methodcallback.emplace("tformpost",temp);
 		temp.pre = nullptr;
-		temp.regfun = testcorssimple;
-		methodcallback.emplace("api/user/info",temp);
+		temp.regfun = testformmultipart;
+		methodcallback.emplace("tfilepost",temp);
 		temp.pre = nullptr;
-		temp.regfun = testsqltuple;
-		methodcallback.emplace("mtuple",temp);
+		temp.regfun = testformjsonpost;
+		methodcallback.emplace("tjsonpost",temp);
+		temp.pre = nullptr;
+		temp.regfun = testformxmlpost;
+		methodcallback.emplace("txmlupload",temp);
+		temp.pre = nullptr;
+		temp.regfun = testuploadpostfile;
+		methodcallback.emplace("addpostfile",temp);
+		temp.pre = nullptr;
+		temp.regfun = testhello;
+		methodcallback.emplace("hello",temp);
+		temp.pre = nullptr;
+		temp.regfun = testhellobusy;
+		methodcallback.emplace("hellobusy",temp);
+		temp.pre = nullptr;
+		temp.regfun = testhttpclient_get_body;
+		methodcallback.emplace("testhttpclient1",temp);
+		temp.pre = nullptr;
+		temp.regfun = testhttpclient_get_timebody;
+		methodcallback.emplace("testhttpclient3",temp);
+		temp.pre = nullptr;
+		temp.regfun = testhttpclient_get_file;
+		methodcallback.emplace("testhttpclient2",temp);
+		temp.pre = nullptr;
+		temp.regfun = testjsonreflect;
+		methodcallback.emplace("testjsonreflect",temp);
+		temp.pre = nullptr;
+		temp.regfun = testmodelfromjson;
+		methodcallback.emplace("mfromjson",temp);
+		temp.pre = nullptr;
+		temp.regfun = testmysqlinsert;
+		methodcallback.emplace("minsert",temp);
+		temp.pre = nullptr;
+		temp.regfun = testmysqlpagebar;
+		methodcallback.emplace("mpagebar",temp);
+		temp.pre = nullptr;
+		temp.regfun = testormcache;
+		methodcallback.emplace("testormcache",temp);
+		temp.pre = nullptr;
+		temp.regfun = testormcacheb;
+		methodcallback.emplace("testormcacheb",temp);
+		temp.pre = nullptr;
+		temp.regfun = testormcachec;
+		methodcallback.emplace("testormcachec",temp);
+		temp.pre = nullptr;
+		temp.regfun = testormclient;
+		methodcallback.emplace("testormclient",temp);
+		temp.pre = nullptr;
+		temp.regfun = testpzcache;
+		methodcallback.emplace("testcache",temp);
+		temp.pre = nullptr;
+		temp.regfun = testshowcache;
+		methodcallback.emplace("testshowcache",temp);
+		temp.pre = nullptr;
+		temp.regfun = testqrcode;
+		methodcallback.emplace("testqrcode",temp);
+		temp.pre = nullptr;
+		temp.regfun = testrand;
+		methodcallback.emplace("testrand",temp);
+		temp.pre = nullptr;
+		temp.regfun = testrestfulpath;
+		methodcallback.emplace("user/info",temp);
+		temp.pre = nullptr;
+		temp.regfun = testrestfulprofilepath;
+		methodcallback.emplace("user/profile",temp);
+		temp.pre = nullptr;
+		temp.regfun = testsendmaildo;
+		methodcallback.emplace("testsendmaildo",temp);
 		temp.pre = nullptr;
 		temp.regfun = testsetsession;
 		methodcallback.emplace("testsetsession",temp);
@@ -251,8 +248,11 @@ namespace http
 		temp.regfun = testshowsession;
 		methodcallback.emplace("testshowsession",temp);
 		temp.pre = nullptr;
-		temp.regfun = api_dev_hostcors;
-		methodcallback.emplace("api/dev/hostcors",temp);
+		temp.regfun = testsqltuple;
+		methodcallback.emplace("mtuple",temp);
+		temp.pre = nullptr;
+		temp.regfun = teststrip_html;
+		methodcallback.emplace("teststrip_html",temp);
 
 
     }

--- a/orm/cms/include/articlebase.h
+++ b/orm/cms/include/articlebase.h
@@ -17,7 +17,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include "mysql.h"
+#include "unicode.h"
 namespace orm { 
    
      namespace cms { 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,24 @@
+{
+    "name": "paozhu",
+    "version-string": "1.4.6",
+    "dependencies": [
+        {
+            "name": "openssl"
+        },
+        {
+            "name": "brotli"
+        },
+        {
+            "name": "libgd"
+        },
+        {
+            "name": "libqrencode"
+        },
+        {
+            "name": "asio"
+        },
+        {
+            "name": "libmysql"
+        }
+    ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
             "name": "libqrencode"
         },
         {
-            "name": "libmysql"
+            "name": "libmariadb"
         },
         {
             "name": "boost-filesystem"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,9 +6,6 @@
             "name": "openssl"
         },
         {
-            "name": "libqrencode"
-        },
-        {
             "name": "libmariadb"
         },
         {
@@ -27,16 +24,25 @@
             "name": "asio"
         },
         {
-            "name": "libgd"
-        },
-        {
             "name": "zlib"
-        },
-        {
-            "name": "libpng"
-        },
-        {
-            "name": "freetype"
         }
-    ]
+    ],
+    "features": {
+        "boost": {
+            "description": "enable boost",
+            "dependencies": [
+                "boost"
+            ]
+        },
+        "gd": {
+            "description": "enable libgd",
+            "dependencies": [
+                "pkgconf",
+                "libgd",
+                "freetype",
+                "libpng",
+                "libqrencode"
+            ]
+        }
+    }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,24 +1,42 @@
 {
     "name": "paozhu",
-    "version-string": "1.4.6",
+    "version": "1.4.6",
     "dependencies": [
         {
             "name": "openssl"
         },
         {
-            "name": "brotli"
-        },
-        {
-            "name": "libgd"
-        },
-        {
             "name": "libqrencode"
+        },
+        {
+            "name": "libmysql"
+        },
+        {
+            "name": "boost-filesystem"
+        },
+        {
+            "name": "boost-dll"
+        },
+        {
+            "name": "boost-coroutine"
+        },
+        {
+            "name": "brotli"
         },
         {
             "name": "asio"
         },
         {
-            "name": "libmysql"
+            "name": "libgd"
+        },
+        {
+            "name": "zlib"
+        },
+        {
+            "name": "libpng"
+        },
+        {
+            "name": "freetype"
         }
     ]
 }

--- a/vendor/httpserver/include/client_session.h
+++ b/vendor/httpserver/include/client_session.h
@@ -32,12 +32,13 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
+
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
 #ifndef WIN32
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #ifdef WIN32

--- a/vendor/httpserver/include/http2_define.h
+++ b/vendor/httpserver/include/http2_define.h
@@ -29,12 +29,12 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
 #ifndef WIN32
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #ifdef WIN32

--- a/vendor/httpserver/include/http_header.h
+++ b/vendor/httpserver/include/http_header.h
@@ -81,6 +81,9 @@ struct uploadfile_t
     unsigned int size;
     unsigned char error;
 };
+#ifdef _WIN32
+#undef DELETE
+#endif
 enum HEAD_METHOD
 {
     UNKNOW,

--- a/vendor/httpserver/include/http_socket.h
+++ b/vendor/httpserver/include/http_socket.h
@@ -28,12 +28,12 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
 #ifndef WIN32
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #ifdef WIN32

--- a/vendor/httpserver/include/server.h
+++ b/vendor/httpserver/include/server.h
@@ -29,12 +29,12 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
 #ifndef WIN32
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #ifdef WIN32

--- a/vendor/httpserver/include/terminal_color.h
+++ b/vendor/httpserver/include/terminal_color.h
@@ -24,6 +24,7 @@
 #define BOLDCYAN "\033[1m\033[36m"    /* Bold Cyan */
 #define BOLDWHITE "\033[1m\033[37m"   /* Bold White */
 
+#undef ERROR
 
 #ifdef DEBUG
 #define ERROR(...)  \

--- a/vendor/httpserver/include/threadpool.h
+++ b/vendor/httpserver/include/threadpool.h
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <cstddef>
 #include <stdio.h>
-#include <sys/socket.h>
 #include <unistd.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -20,7 +19,6 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <array>
 #include <cstdio>
 #include <iostream>
@@ -37,6 +35,11 @@
 #include <map>
 #include <thread>
 #include <mutex>
+
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <sys/wait.h>
+#endif
 
 #include <condition_variable>
 #include <future>

--- a/vendor/httpserver/src/directory_fun.cpp
+++ b/vendor/httpserver/src/directory_fun.cpp
@@ -217,7 +217,11 @@ std::string displaydirectory(std::string localpath, std::string urlpath,
       if (fs::is_regular_file(entry.status()))
       {
         pathfilelists.filename = filename.string();
+#ifndef _WIN32
         pathfilelists.ext      = entry.path().extension();
+#else
+        pathfilelists.ext      = entry.path().extension().string();
+#endif
 
         long long filesize = fs::file_size(entry);
         pathfilelists.size = filesize;

--- a/vendor/httpserver/src/http_domain.cpp
+++ b/vendor/httpserver/src/http_domain.cpp
@@ -10,6 +10,10 @@
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
+#ifdef ENABLE_VCPKG
+#include <openssl/ssl.h>
+#endif
+
 #ifndef WIN32
 #include <unistd.h>
 #endif

--- a/vendor/httpserver/src/http_domain.cpp
+++ b/vendor/httpserver/src/http_domain.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 
@@ -16,6 +15,7 @@
 
 #ifndef WIN32
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #ifdef WIN32

--- a/vendor/httpserver/src/https_brotli.cpp
+++ b/vendor/httpserver/src/https_brotli.cpp
@@ -8,7 +8,7 @@ namespace http
     {
         std::array<unsigned char, 2048> buffer;
         auto instance = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
-        unsigned long available_in = data.length(), available_out = buffer.size();
+        size_t available_in = data.length(), available_out = buffer.size();
         const unsigned char *next_in = reinterpret_cast<const unsigned char *>(data.c_str());
         unsigned char *next_out = buffer.data();
 
@@ -29,7 +29,7 @@ namespace http
     {
         auto instance = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
 
-        unsigned long available_in = data.length(), available_out = buffer_size;
+        size_t available_in = data.length(), available_out = buffer_size;
         const unsigned char *next_in = reinterpret_cast<const unsigned char *>(data.c_str());
         unsigned char *next_out = buffer;
 
@@ -51,7 +51,7 @@ namespace http
         std::array<unsigned char, 2048> buffer;
         BrotliDecoderResult per_result;
         auto instance = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
-        unsigned long available_in = data.length(), available_out = buffer.size();
+        size_t available_in = data.length(), available_out = buffer.size();
         const unsigned char *next_in = reinterpret_cast<const unsigned char *>(data.c_str());
         unsigned char *next_out = buffer.data();
 
@@ -71,7 +71,7 @@ namespace http
     {
         BrotliDecoderResult per_result;
         auto instance = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
-        unsigned long available_in = data.length(), available_out = buffer_size;
+        size_t available_in = data.length(), available_out = buffer_size;
         const unsigned char *next_in = reinterpret_cast<const unsigned char *>(data.c_str());
         unsigned char *next_out = buffer;
         do

--- a/vendor/httpserver/src/server.cpp
+++ b/vendor/httpserver/src/server.cpp
@@ -33,6 +33,10 @@
 #include "http_so_common_api.h"
 #endif
 
+#ifdef ENABLE_VCPKG
+#include <openssl/ssl.h>
+#endif
+
 #include "mysqlproxyfun.h"
 #include "server_localvar.h"
 #include "debug_log.h"

--- a/vendor/httpserver/src/server.cpp
+++ b/vendor/httpserver/src/server.cpp
@@ -2718,10 +2718,12 @@ void httpserver::httpwatch()
     error_path = currentpath;
     currentpath.append("access.log");
     error_path.append("error.log");
-    struct flock lockstr        = {};
     unsigned int mysqlpool_time = 1;
     std::size_t n_write         = 0;
     updatetimetemp              = 0;
+#ifndef _WIN32
+    struct flock lockstr        = {};
+#endif
     for (;;)
     {
         if (catch_num > 10)
@@ -2763,6 +2765,7 @@ void httpserver::httpwatch()
                     continue;
                 }
 
+#ifndef _WIN32
                 lockstr.l_type   = F_WRLCK;
                 lockstr.l_whence = SEEK_END;
                 lockstr.l_start  = 0;
@@ -2775,6 +2778,14 @@ void httpserver::httpwatch()
                     close(fd);
                     continue;
                 }
+#else
+                auto native_handle = (HANDLE) _get_osfhandle(fd);
+                auto file_size = GetFileSize(native_handle, nullptr);
+                if (!LockFile(native_handle, file_size, 0, file_size, 0)) {
+                    close(fd);
+                    continue;
+                }
+#endif
                 std::unique_lock<std::mutex> loglock(log_mutex);
                 while (!access_loglist.empty())
                 {
@@ -2783,12 +2794,19 @@ void httpserver::httpwatch()
                 }
                 loglock.unlock();
 
+#ifndef _WIN32
                 lockstr.l_type = F_UNLCK;
                 if (fcntl(fd, F_SETLK, &lockstr) == -1)
                 {
                     close(fd);
                     continue;
                 }
+#else
+                if (!UnlockFile(native_handle, file_size, 0, file_size, 0)) {
+                    close(fd);
+                    continue;
+                }
+#endif
                 close(fd);
             }
 
@@ -2801,6 +2819,7 @@ void httpserver::httpwatch()
                     continue;
                 }
 
+#ifndef _WIN32
                 lockstr.l_type   = F_WRLCK;
                 lockstr.l_whence = SEEK_END;
                 lockstr.l_start  = 0;
@@ -2813,6 +2832,15 @@ void httpserver::httpwatch()
                     close(fd);
                     continue;
                 }
+#else
+                auto native_handle = (HANDLE) _get_osfhandle(fd);
+                auto file_size = GetFileSize(native_handle, nullptr);
+                if (!LockFile(native_handle, file_size, 0, file_size, 0)) {
+                    close(fd);
+                    continue;
+                }
+#endif
+
                 std::unique_lock<std::mutex> loglock(log_mutex);
                 while (!error_loglist.empty())
                 {
@@ -2821,12 +2849,19 @@ void httpserver::httpwatch()
                 }
                 loglock.unlock();
 
+#ifndef _WIN32
                 lockstr.l_type = F_UNLCK;
                 if (fcntl(fd, F_SETLK, &lockstr) == -1)
                 {
                     close(fd);
                     continue;
                 }
+#else
+                if (!UnlockFile(native_handle, file_size, 0, file_size, 0)) {
+                    close(fd);
+                    continue;
+                }
+#endif
                 close(fd);
             }
             if (n_write > 0)

--- a/vendor/httpserver/src/threadpool.cpp
+++ b/vendor/httpserver/src/threadpool.cpp
@@ -15,10 +15,13 @@
 #include <fstream>
 #include <algorithm>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <array>
 #include <set>
 #include <memory>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
 
 #include <ctime>
 #include <map>


### PR DESCRIPTION
- Retain the original build mode and add the ENABLE_VCPKG option to enable vcpkg
- Supports the use of vcpkg features to enable specific features
- Added msys2 toolchain support for Windows platform builds

> Note: Not only for Windows platforms, vcpkg also supports building dependencies in the same way on macos and linux distributions

close #2