### PR TITLE
[fix] ports/libqrencode build error on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,21 @@ if (ENABLE_VCPKG)
         # set(QRENCODE_LIBRARIES optimized ${QRENCODE_LIBRARY_RELEASE} debug ${QRENCODE_LIBRARY_DEBUG})
         target_include_directories(paozhu PRIVATE ${QRENCODE_INCLUDE_DIR})
         target_link_libraries(paozhu ${QRENCODE_LIBRARY_RELEASE})
-        MESSAGE(STATUS ${QRENCODE_LIBRARY_RELEASE})
+        # MESSAGE(STATUS ${QRENCODE_LIBRARY_RELEASE})
+
+        # warning: Fixed an issue where ports/libqrencode would not automatically
+        #          copy dll files to the bin directory
+        if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+            string(LENGTH ${QRENCODE_LIBRARY_RELEASE} len)
+            math(EXPR len "${len} - 2")
+            string(SUBSTRING ${QRENCODE_LIBRARY_RELEASE} 0 ${len} qrencode_dll)
+            message(STATUS ${qrencode_dll})
+            add_custom_command(
+                    TARGET paozhu POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${qrencode_dll} ${CMAKE_CURRENT_SOURCE_DIR}/bin/
+            )
+        endif ()
 
         find_package(PNG REQUIRED)
         target_link_libraries(paozhu PNG::PNG)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg.git",
+        "baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2"
+    }
+}


### PR DESCRIPTION
- The **baseline** is used to limit the vcpkg ports version
- Fix 0xc0000135 error caused by libqrencode build error