### PR TITLE
build[vcpkg]: Make boost completely optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,9 +196,12 @@ if (ENABLE_VCPKG)
     find_package(asio CONFIG REQUIRED)
     target_link_libraries(paozhu asio::asio)
 
-    set(Boost_NO_WARN_NEW_VERSIONS ON)
-    find_package(Boost REQUIRED COMPONENTS filesystem coroutine)
-    target_link_libraries(paozhu Boost::boost Boost::filesystem Boost::coroutine)
+    if (ENABLE_BOOST)
+        add_compile_definitions(ENABLE_BOOST)
+        set(Boost_NO_WARN_NEW_VERSIONS ON)
+        find_package(Boost REQUIRED COMPONENTS filesystem coroutine)
+        target_link_libraries(paozhu Boost::boost Boost::filesystem Boost::coroutine)
+    endif ()
 
     find_package(OpenSSL REQUIRED)
     target_link_libraries(paozhu OpenSSL::Crypto OpenSSL::SSL)
@@ -284,6 +287,7 @@ message("---ENABLE_BOOST-----")
 find_package(Boost REQUIRED
              COMPONENTS system filesystem)
 if(Boost_FOUND)
+    add_compile_definitions(ENABLE_BOOST)
     include_directories("${Boost_INCLUDE_DIRS}/boost")
 
     MESSAGE( STATUS "Boost_INCLUDE_DIRS = ${Boost_INCLUDE_DIRS}")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,6 @@
     "default-registry": {
         "kind": "git",
         "repository": "https://github.com/microsoft/vcpkg.git",
-        "baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2"
+        "baseline": "c8696863d371ab7f46e213d8f5ca923c4aef2a00"
     }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,21 +1,12 @@
 {
     "name": "paozhu",
-    "version": "1.4.6",
+    "version": "1.5.3",
     "dependencies": [
         {
             "name": "openssl"
         },
         {
             "name": "libmariadb"
-        },
-        {
-            "name": "boost-filesystem"
-        },
-        {
-            "name": "boost-dll"
-        },
-        {
-            "name": "boost-coroutine"
         },
         {
             "name": "brotli"
@@ -31,7 +22,10 @@
         "boost": {
             "description": "enable boost",
             "dependencies": [
-                "boost"
+                "boost",
+                "boost-coroutine",
+                "boost-dll",
+                "boost-filesystem"
             ]
         },
         "gd": {


### PR DESCRIPTION
## Changes

- Make boost completely optional
- Change project version number
- Update vcpkg base-line

## Tests

Build Success

- ✅Windows 11
- ✅Ubuntu 22.04
- ✅macOS Big Sur(x64)
